### PR TITLE
[enhancement/phase1] JP-001 - Major Change

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,54 +13,54 @@ $ npm i json-parsify
 
 ## Usage
 ```ts
-import { safeJsonParse } from 'json-parsify';
+import { jsonParsify } from 'json-parsify';
 
 console.log('***************');
 const objectJson = '{"name": "John Doe", "age": 24 }';
-const objectJsonResult = safeJsonParse(objectJson);
+const objectJsonResult = jsonParsify(objectJson);
 console.log('Parsed Stringified Object');
 console.log({ objectJSON: objectJsonResult });
 
 console.log('***************');
 const arrayJson = '["John Doe", "Jane Doe"]';
-const arrayJsonResult = safeJsonParse(arrayJson);
+const arrayJsonResult = jsonParsify(arrayJson);
 console.log('Parsed Stringified Array');
 console.log({ arrayJSON: arrayJsonResult });
 
 console.log('***************');
 const numberJson = '3';
-const numberJsonResult = safeJsonParse(numberJson);
+const numberJsonResult = jsonParsify(numberJson);
 console.log('Parsed Stringified Number');
 console.log({ numberJSON: numberJsonResult });
 
 console.log('***************');
 const booleanJson = 'true';
-const booleanJsonResult = safeJsonParse(booleanJson);
+const booleanJsonResult = jsonParsify(booleanJson);
 console.log('Parsed Stringified Boolean');
 console.log({ booleanJSON: booleanJsonResult });
 
 console.log('***************');
-const errorJson = 'this cannot be parsed';
-const errorJsonResult = safeJsonParse(errorJson);
+const errorJson = '{}}';
+const errorJsonResult = jsonParsify(errorJson);
 console.log('Parsed with error');
 console.log({ errorJSON: errorJsonResult });
 
 console.log('***************');
-const errorAndWithDefaultValueJson = 'this cannot be parsed';
-const errorAndWithDefaultValueJsonResult = safeJsonParse(errorAndWithDefaultValueJson, { message: 'Default result'});
+const errorAndWithDefaultValueJson = '{}}';
+const errorAndWithDefaultValueJsonResult = jsonParsify(errorAndWithDefaultValueJson, { message: 'Default result'});
 console.log('Parsed with errorAndWithDefaultValue');
 console.log({ errorAndWithDefaultValueJSON: errorAndWithDefaultValueJsonResult });
 
 console.log('***************');
-const withDefaultValueJson = undefined;
-const withDefaultValueJsonResult = safeJsonParse(withDefaultValueJson, { message: 'Default result'});
+const undefinedWithDefaultValueJson = undefined;
+const undefinedWithDefaultValueJsonResult = jsonParsify(undefinedWithDefaultValueJson, { message: 'Default result'});
 console.log('Parsed with withDefaultValue');
-console.log({ withDefaultValueJSON: withDefaultValueJsonResult });
+console.log({ withDefaultValueJSON: undefinedWithDefaultValueJsonResult });
 
 ```
 
 ### Sample Result from code above:
-```ts
+```sh
 ***************
 Parsed Stringified Object
 { objectJSON: { name: 'John Doe', age: 24 } }
@@ -74,15 +74,14 @@ Parsed Stringified Number
 Parsed Stringified Boolean
 { booleanJSON: true }
 ***************
-Unexpected token h in JSON at position 1
+Unexpected token } in JSON at position 2
 Parsed with error
 { errorJSON: null }
 ***************
-Unexpected token h in JSON at position 1
+Unexpected token } in JSON at position 2
 Parsed with errorAndWithDefaultValue
 { errorAndWithDefaultValueJSON: { message: 'Default result' } }
 ***************
-Unexpected end of JSON input
 Parsed with withDefaultValue
 { withDefaultValueJSON: { message: 'Default result' } }
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-parsify",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -18,6 +18,11 @@
     "parse",
     "safe"
   ],
+  "homepage": "https://github.com/Arjorie/json-parsify/blob/master/README.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Arjorie/json-parsify"
+  },
   "author": "Arjorie Sotelo <arjoriesotelo@gmail.com>",
   "license": "ISC",
   "dependencies": {

--- a/src/lib/json-parse.ts
+++ b/src/lib/json-parse.ts
@@ -1,10 +1,11 @@
-export const safeJsonParse = (str: string = '', defaultVal: any = null): any => {
-    let parseJson: any;
+export const jsonParsify = (str: string | null | undefined, defaultVal: any = null): any => {
+    let parsedJson: any;
+    if (typeof str !== 'string' || str === '') return defaultVal;
     try {
-        parseJson = JSON.parse(str);
+        parsedJson = JSON.parse(str);
     } catch (err: any) {
-        console.warn(err?.message);
-        parseJson = defaultVal;
+        console.error(err?.message);
+        parsedJson = defaultVal;
     }
-    return parseJson;
+    return parsedJson;
 }


### PR DESCRIPTION
- [*] Updated `src/lib/json-parse.ts`
- [*] Updated `package.json`
- [*] Updated `README.md`
- Use `jsonParsify` instead of `safeJsonParse` Example: `jsonParsify('this will cause an error', 'this is a default value');`
- When str passed to `jsonParsify` is `null`, `undefined`, or empty string `''`, will return `defaultVal` else, `null`. Example: `jsonParsify(null, 1);`